### PR TITLE
fix: fix package name to correspond to path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module firebolt-gorm
+module github.com/firebolt-db/firebolt-gorm
 
 go 1.18
 


### PR DESCRIPTION
Change package name since go forces packages to have the same name as the package location path